### PR TITLE
park: A few different parking/pausing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ PRINT_END
 ```
 ;BEFORE_LAYER_CHANGE
 ;[layer_z]
-BEFORE_LAYER_CHANGE HEIGHT=[max_layer_z] LAYER=[layer_num]
+BEFORE_LAYER_CHANGE HEIGHT=[layer_z] LAYER=[layer_num]
 ```
 
 **After layer change G-code**
@@ -373,6 +373,9 @@ Parks the toolhead.
 * `Y` *(default: `variable_park_y`)* - Absolute Y parking coordinate.
 * `Z` *(default: `variable_park_z`)* - Z parking coordinate applied according
   to the `P` parameter.
+* Note: If a print is in progress the larger of the tallest printed layer or the
+  current Z position will be used as the current Z position, to avoid collisions
+  with already printed objects during a sequential print.
 
 #### Marlin Compatibility
 

--- a/filament.cfg
+++ b/filament.cfg
@@ -34,8 +34,8 @@ gcode:
   {% else %}
     G1 E3.0 F{km.load_speed}
     G4 S1
-    G1 E-{priming_length} F{km.load_priming_speed}
-    G1 E-{LENGTH} F{km.load_speed}
+    G1 E{'%.4f' % -priming_length} F{km.load_priming_speed}
+    G1 E{'%.4f' % -LENGTH} F{km.load_speed}
   {% endif %}
   M400
   RESTORE_GCODE_STATE NAME=_LOAD_UNLOAD

--- a/layers.cfg
+++ b/layers.cfg
@@ -12,6 +12,10 @@ gcode:
   {% if height >= 0.0 %}
     SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_layer VALUE="{layer}"
     SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_height VALUE="{height}"
+    {% if printer["gcode_macro _km_layer_run"].clearance_z < height %}
+      SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=clearance_z VALUE="{
+        height}"
+    {% endif %}
   {% endif %}
   _KM_LAYER_RUN BEFORE=1
 
@@ -118,6 +122,7 @@ gcode:
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_height VALUE="{0.0}"
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=tot_layers VALUE="{
     params.LAYERS|int}"
+  SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=clearance_z VALUE="{0.0}"
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=commands VALUE="{{}}"
 
 [gcode_macro _reset_layer_gcode]
@@ -127,6 +132,7 @@ gcode:
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_layer VALUE="{-1}"
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_height VALUE="{0.0}"
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=tot_layers VALUE="{0}"
+  SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=clearance_z VALUE="{0.0}"
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=commands VALUE="{{}}"
 
 [gcode_macro pause_next_layer]
@@ -145,6 +151,7 @@ description: Runs pending commands for the current layer change.
 variable_cur_layer: -1
 variable_cur_height: 0.0
 variable_tot_layers: 0
+variable_clearance_z: 0.0
 variable_commands: {}
 gcode:
   {% set BEFORE = params.BEFORE|int %}

--- a/park.cfg
+++ b/park.cfg
@@ -24,18 +24,25 @@ gcode:
   {% set Z = params.Z|default(km.park_z)|float %}
   _CHECK_KINEMATIC_LIMITS X="{X}" Y="{Y}" Z="{Z}"
 
+  # Use the taller of the highest printed layer or the current Z height, which
+  # should helps crashes e.g. when a sequential print in progress.
+  {% set clearance_z = (printer["gcode_macro _km_layer_run"].clearance_z,
+                        printer.gcode_move.gcode_position.z) | max %}
+
   # Convert everything to absolute coordinates.
   # P == 1 is absolute, so needs no adjustment.
   {% if P == 0 %} # Move absolute to Z if below current Z
-    {% if printer.gcode_move.gcode_position.z > Z %}
-      {% set Z = printer.gcode_move.gcode_position.z %}
+    {% if clearance_z > Z %}
+      {% set Z = clearance_z %}
     {% endif %}
   {% elif P == 2 %} # Move Z relative
-    {% set Z = Z + printer.gcode_move.gcode_position.z %}
+    {% set Z = Z + clearance_z %}
   {% elif P != 1 %}
     {action_raise_error("Invalid parameter P=%i. Value must be 0, 1, or 2." |
         format(P)) }
   {% endif %}
+
+  # Clamp to the printer limits.
   {% set Z = ((Z, max_z)|min, min_z)|max %}
 
   SAVE_GCODE_STATE NAME=PARK

--- a/pause_resume_cancel.cfg
+++ b/pause_resume_cancel.cfg
@@ -21,9 +21,9 @@ gcode:
     SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_z VALUE="{position.z}"
     SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_e VALUE="{E}"
     SAVE_GCODE_STATE NAME=PAUSE_override_state
-    BASE_PAUSE
+    _KM_PAUSE_BASE
     G91
-    G1 E{-1.0 * E} F{km.load_speed}
+    G1 E{'%.4f' % -E} F{km.load_speed}
     PARK P=2{% for k in params|select("in", "XYZ") %}
       {" "~k~"="~params[k]}
     {% endfor %}
@@ -104,7 +104,7 @@ gcode:
     # Move back above last position to reduce chance of drooling on print.
     G0 X{saved_x} Y{saved_y} F{km.travel_speed_xy}
     RESTORE_GCODE_STATE NAME=PAUSE_override_state MOVE=1
-    BASE_RESUME
+    _KM_RESUME_BASE
   {% else %}
     { action_respond_info("Printer is not paused.") }
   {% endif %}
@@ -121,7 +121,7 @@ gcode:
   {% else %}
     { action_respond_info("No print from SD card in progress.") }
   {% endif %}
-  BASE_CANCEL_PRINT
+  _KM_CANCEL_PRINT_BASE
   {% if was_paused %}
     RESTORE_GCODE_STATE NAME=PAUSE_override_state MOVE=0
   {% endif %}


### PR DESCRIPTION
* Ensure the head is above tallest printed layer when pausing a print.
* Change Prusa Slicer config since it had a bug in sequential prints.
* Fix bug introduced by mass macro rename before initial check-in.
* Fixed some issues/inconsistencies in signed parameters.