### PR TITLE
kinematics: Add lazy homing to G28

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,16 @@ adjustments made in clients like Mainsail and Fluidd will not be scaled
 [custom LCD menus]](#lcd-menus) will also replace the temperature controls with
 non-scaling versions. If you use the stock menus you'll get scaled values.*
 
+### Kinematics
+
+#### `G28`
+
+Extends the `G28` command to add lazy homing by not re-homing already homed axes
+when the `O` argument is included. See Klipper `G28` documentation for general
+information and detail on the other arguments.
+
+* `O` - Omits axes from the homing procedure if they are already homed.
+
 ### Layer Triggers
 
 Provides the capability to run user-specified g-code commands at arbitrary layer

--- a/kinematics.cfg
+++ b/kinematics.cfg
@@ -26,3 +26,34 @@ gcode:
        | format(params.E|float|abs, printer.configfile.settings[
                                       "extruder"].max_extrude_only_distance))}
   {% endif %}
+
+[gcode_macro g28]
+description: Wraps the G28 command to add the Marlin "O" parameter so that
+  already homed axes will not be homed again. See the Klipper documentation on
+  G28 for the behavior of the other parameters.
+  Usage: G28 [O] ...
+rename_existing: G28.6245197
+gcode:
+  {% set do_homing = True %}
+  {% if 'O' in params %}
+    # No axes means home them all, so add the list in before pruning.
+    {% if params|select('in', 'XYZ')|list|length == 0 %}
+      {% for k in 'XYZ' %}
+        {% set dummy = params.__setitem__(k, '') %}
+      {% endfor %}
+    {% endif %}
+    # Prune out the already homed axes.
+    {% for k in params|select('in', 'XYZ')|list %}
+      {% if k|lower in printer.toolhead.homed_axes %}
+        {% set dummy = params.__delitem__(k) %}
+      {% endif %}
+    {% endfor %}
+    {% set dummy = params.__delitem__('O') %}
+    # If we don't have anything left we can skip homing.
+    {% set do_homing = params|select('in', 'XYZ')|list|length > 0 %}
+  {% else %}
+  {% endif %}
+
+  {% if do_homing %}
+    G28.6245197{% for k in params %}{' ' ~ k ~ '=' ~ params[k]}{% endfor %}
+  {% endif %}


### PR DESCRIPTION
Implements Marlin's "O" parameter to perform lazy homing.