### PR TITLE
probe_count can be a single integer

### DIFF
--- a/optional/bed_mesh.cfg
+++ b/optional/bed_mesh.cfg
@@ -42,11 +42,18 @@ gcode:
       {% set mesh_max_y = safe_max_y %}
     {% endif %}
 
-    {% set max_x_probes = (params.PROBE_COUNT |
+    # Klipper allows probe_count to be a single integer, this handles that case
+    {% if ',' in bed_mesh.probe_count %}
+      {% set max_x_probes = (params.PROBE_COUNT |
                            default(bed_mesh.probe_count)).split(",")[0]|int %}
-    {% set max_y_probes = (params.PROBE_COUNT |
+      {% set max_y_probes = (params.PROBE_COUNT |
                            default(bed_mesh.probe_count)).split(",")[1]|int %}
-
+    {% else %}
+      %{ set max_x_probes = (params.PROBE_COUNT |
+                           default(bed_mesh.probe_count))|int %}
+      {% set max_y_probes = (params.PROBE_COUNT |
+                           default(bed_mesh.probe_count))|int %}
+    {% endif %}
     {% set x_probes = (max_x_probes * (mesh_max_x - mesh_min_x) /
                       (safe_max_x - safe_min_x) * probe_count_scale)
                       | round(0) | int %}

--- a/optional/bed_mesh.cfg
+++ b/optional/bed_mesh.cfg
@@ -49,7 +49,7 @@ gcode:
       {% set max_y_probes = (params.PROBE_COUNT |
                            default(bed_mesh.probe_count)).split(",")[1]|int %}
     {% else %}
-      %{ set max_x_probes = (params.PROBE_COUNT |
+      {% set max_x_probes = (params.PROBE_COUNT |
                            default(bed_mesh.probe_count))|int %}
       {% set max_y_probes = (params.PROBE_COUNT |
                            default(bed_mesh.probe_count))|int %}


### PR DESCRIPTION
Klipper kept giving me array reference errors using this macro.  This was because my bed_mesh probe_count value is a single integer.

This PR adds a check to see if there's a , value in the probe_count, and handles the case where it's not (single integer) by duplicating it for both x and y values