### PR TITLE
error messages fixed for Y and Z axis

### DIFF
--- a/kinematics.cfg
+++ b/kinematics.cfg
@@ -12,12 +12,12 @@ gcode:
                                  toolhead.axis_maximum.x))}
   {% elif params.Y and (params.Y|float < toolhead.axis_minimum.y or
                         params.Y|float > toolhead.axis_maximum.y) %}
-    {action_raise_error("X[%.3f] must be between %.3f and %.3f."
+    {action_raise_error("Y[%.3f] must be between %.3f and %.3f."
                         | format(params.Y|float, toolhead.axis_minimum.y,
                                  toolhead.axis_maximum.y))}
   {% elif params.Z and (params.Z|float < toolhead.axis_minimum.z or
                         params.Z|float > toolhead.axis_maximum.z) %}
-    {action_raise_error("X[%.3f] must be between %.3f and %.3f."
+    {action_raise_error("Z[%.3f] must be between %.3f and %.3f."
                         | format(params.Z|float, toolhead.axis_minimum.z,
                                  toolhead.axis_maximum.z))}
   {% elif params.E and (params.E|float|abs > printer.configfile.settings[


### PR DESCRIPTION
I noticed in the macro "_check_kinematic_limits" for Y & Z axis the error messages were referencing the X axis. basically no matter if X, Y or Z axis had an error, it was always talking about X axis in the error message.