### PR TITLE
start_end: Add Cura config support

### DIFF
--- a/layers.cfg
+++ b/layers.cfg
@@ -7,7 +7,7 @@
 description: Add this to the "before layer change" input box in the slicer.
   Usage: BEFORE_LAYER_CHANGE HEIGHT=<current_height> LAYER=<current_layer>
 gcode:
-  {% set height = params.HEIGHT|default(0.0)|float %}
+  {% set height = params.HEIGHT|default(printer.toolhead.position.z)|float %}
   {% set layer = params.LAYER|default(-1)|int %}
   {% if height >= 0.0 %}
     SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_layer VALUE="{layer}"
@@ -118,9 +118,9 @@ gcode:
     {action_respond_info(layers|join('\n'))}
   {% endif %}
 
-[gcode_macro _init_layer_gcode]
+[gcode_macro init_layer_gcode]
 description: Clears scheduled gcode commands and state for all layers.
-  Usage: _INIT_LAYER_GCODE LAYERS=<num>
+  Usage: INIT_LAYER_GCODE LAYERS=<num>
 gcode:
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_layer VALUE="{-1}"
   SET_GCODE_VARIABLE MACRO=_km_layer_run VARIABLE=cur_height VALUE="{0.0}"

--- a/start_end.cfg
+++ b/start_end.cfg
@@ -12,9 +12,13 @@ gcode:
   {% set EXTRUDER = params.EXTRUDER|default(params.EXTRUDER_TEMP)|float %}
   {% set CHAMBER = params.CHAMBER|default(0)|float
                    if "chamber" in printer.heaters.available_heaters else 0.0 %}
+  {% set settings = printer["gcode_macro print_start_set"].settings %}
+  {% set MESH_MIN = params.MESH_MIN|default(settings.MESH_MIN)|default(None) %}
+  {% set MESH_MAX = params.MESH_MAX|default(settings.MESH_MAX)|default(None) %}
+  {% set LAYERS = params.LAYERS|default(settings.LAYERS)|default(-1)|int %}
   {% set km = printer["gcode_macro _km_globals"] %}
 
-  _INIT_LAYER_GCODE LAYERS="{params.LAYERS|default(0)|int}"
+  INIT_LAYER_GCODE LAYERS="{LAYERS}"
   {% if CHAMBER > 0.0 %}
     M141 S{CHAMBER}
   {% endif %}
@@ -42,8 +46,8 @@ gcode:
   {% if km.start_level_bed_at_temp %}
     M104 S{EXTRUDER} # set the final extruder target temperature
     G28 Z # Re-home only the Z axis now that the bed has stabilized.
-    BED_MESH_CALIBRATE MESH_MIN={params.MESH_MIN|default("0,0")
-                     } MESH_MAX={params.MESH_MAX|default("0,0")}
+    BED_MESH_CALIBRATE{% if MESH_MIN %} MESH_MIN={MESH_MIN}{% endif
+                    %}{% if MESH_MAX %} MESH_MAX={MESH_MAX}{% endif %}
     PARK
   {% endif %}
   {% if CHAMBER > 0.0 %}
@@ -53,6 +57,15 @@ gcode:
   M109 S{EXTRUDER}
   # apply Z offset for bed surface (just in case it was reset).
   _APPLY_BED_SURFACE_OFFSET
+
+[gcode_macro print_start_set]
+description: Inserted by slicer to set values used by PRINT_START.
+  Usage: PRINT_START_SET <VARIABLE>=<value>
+variable_settings: {}
+gcode:
+  {%for k in params %}
+    {% set dummy = settings.__setitem__(k|upper, params[k]) %}
+  {% endfor %}
 
 [gcode_macro print_end]
 description: Inserted by slicer at end of print.


### PR DESCRIPTION
Changes some parameter passing and default handling in print start and layer trigger code to work with Cura (and just be a bit more robust). Also adds Cura config instructions to readme.

Fixes issue #8.