### PR TITLE
Should be park_y for Y axis

### DIFF
--- a/park.cfg
+++ b/park.cfg
@@ -19,7 +19,7 @@ gcode:
   # Z position type from G27 (if below, absolute, relative)
   {% set P = (params.P|default(2))|int %} # Default to 2 because it's sanest.
   {% set X = params.X|default(km.park_x)|float %}
-  {% set Y = params.Y|default(km.park_x)|float %}
+  {% set Y = params.Y|default(km.park_y)|float %}
   {% set Z = params.Z|default(km.park_z)|float %}
 
   _CHECK_KINEMATIC_LIMITS X="{X}" Y="{Y}" Z="{Z}"


### PR DESCRIPTION
It looks like you made a typo here. It showed up on my printer because I can't use the first 26mm of my Y axis and my Y axis homes to Y max.