### PR TITLE
fluidd compatibility: Upper case macro names

### DIFF
--- a/pause_resume_cancel.cfg
+++ b/pause_resume_cancel.cfg
@@ -3,7 +3,7 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 # Enables pause/resume functionality
-[gcode_macro pause]
+[gcode_macro PAUSE]
 description: Pauses the current print.
   Usage: PAUSE [X=<pos>] [Y=<pos>] [Z=<pos>] [E=<retract_length>] [B=<beeps>]
 rename_existing: _KM_PAUSE_BASE
@@ -38,7 +38,7 @@ gcode:
     { action_respond_info("Print from SD card is not in progress.") }
   {% endif %}
 
-[gcode_macro m600]
+[gcode_macro M600]
 description: Pauses the current print.
   Usage: M600 [B<beeps>] [E<pos>] [L<pos>] [R<temp>] [U<pos>] [X<pos>] [Y<pos>]
               [Z<pos>]
@@ -49,19 +49,19 @@ gcode:
   UNLOAD_FILAMENT{% if 'U' in params %} LENGTH={params.U}{% endif %}
   {% if 'R' in params %}M109 S{params.R}{% endif %}
 
-[gcode_macro m601]
+[gcode_macro M601]
 description: Pauses the current print.
   Usage: M601
 gcode:
   PAUSE
 
-[gcode_macro m602]
+[gcode_macro M602]
 description: Resumes the currently paused print.
   Usage: M602
 gcode:
   RESUME
 
-[gcode_macro m24]
+[gcode_macro M24]
 rename_existing: M24.6245197
 gcode:
   {% if printer.pause_resume.is_paused %}
@@ -70,12 +70,12 @@ gcode:
   M24.6245197
   {% endif %}
 
-[gcode_macro m25]
+[gcode_macro M25]
 rename_existing: M25.6245197
 gcode:
   PAUSE
 
-[gcode_macro resume]
+[gcode_macro RESUME]
 description: Resumes the currently paused print.
   Usage: RESUME [E<pos>]
 rename_existing: _KM_RESUME_BASE
@@ -116,7 +116,7 @@ gcode:
     { action_respond_info("Printer is not paused.") }
   {% endif %}
 
-[gcode_macro cancel_print]
+[gcode_macro CANCEL_PRINT]
 description: Cancels the current print.
   Usage: CANCEL_PRINT
 rename_existing: _KM_CANCEL_PRINT_BASE
@@ -134,7 +134,7 @@ gcode:
   {% endif %}
   CLEAR_PAUSE
 
-[gcode_macro clear_pause]
+[gcode_macro CLEAR_PAUSE]
 description: Clears the current pause state.
   Usage: CLEAR_PAUSE
 rename_existing: _KM_CLEAR_PAUSE


### PR DESCRIPTION
fluidd expects CANCEL_PRINT and friends to be uppercase.