### PR TITLE
readme: add missing opening code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ path: ~/gcode_files # UPDATE THIS FOR YOUR PATH!!!
 ```
 
 # Uncomment the sections below if Fluidd complains (because it's confused).
+```
 #[gcode_macro CANCEL_PRINT]
 #rename_existing: CANCEL_PRINT_FAKE_BASE
 #gcode: CANCEL_PRINT_FAKE_BASE {rawparams}


### PR DESCRIPTION
Looks like we were missing a "```" which made the readme super confusing to read.