### PR TITLE
temperature_wait_scaled MAXIMUM check fix and start_extruder_temperature option

### DIFF
--- a/globals.cfg
+++ b/globals.cfg
@@ -65,7 +65,7 @@ variable_start_clear_adjustments_at_end: True
 variable_start_end_park_y: 0.0
 # Fixed extruder temperature during pre-warmup in PRINT_START.
 # variable_start_extruder_preheat_scale must be 0 if set.
-variable_start_extruder_temperature: 0
+variable_start_extruder_temperature: 0.0
 # Extruder scale factor during pre-warmup in PRINT_START.
 variable_start_extruder_preheat_scale: 0.5
 # Set the extruder target temp before bed level in PRINT_START.
@@ -245,8 +245,8 @@ gcode:
         km.print_min[1] < toolhead.axis_minimum.y %}
     {% set dummy = output.append("print_min is invalid.") %}
   {% endif %}
-  {% if km.start_extruder_temperature > 0 and
-        km.start_extruder_preheat_scale > 0 %}
+  {% if km.start_extruder_temperature > 0.0 and
+        km.start_extruder_preheat_scale > 0.0 %}
     {% set dummy = output.append(
       "using extruder_temperature and extruder_preheat_scale at the same time.") %}
   {% endif %}

--- a/globals.cfg
+++ b/globals.cfg
@@ -63,6 +63,9 @@ variable_start_bed_heat_overshoot: 2.0
 variable_start_clear_adjustments_at_end: True
 # Final Y position of toolhead in PRINT_END. Defaults to print_max Y.
 variable_start_end_park_y: 0.0
+# Fixed extruder temperature during pre-warmup in PRINT_START.
+# variable_start_extruder_preheat_scale must be 0 if set.
+variable_start_extruder_temperature: 0
 # Extruder scale factor during pre-warmup in PRINT_START.
 variable_start_extruder_preheat_scale: 0.5
 # Set the extruder target temp before bed level in PRINT_START.
@@ -241,6 +244,11 @@ gcode:
   {% if km.print_min[0] < toolhead.axis_minimum.x or
         km.print_min[1] < toolhead.axis_minimum.y %}
     {% set dummy = output.append("print_min is invalid.") %}
+  {% endif %}
+  {% if km.start_extruder_temperature > 0 and
+        km.start_extruder_preheat_scale > 0 %}
+    {% set dummy = output.append(
+      "using extruder_temperature and extruder_preheat_scale at the same time.") %}
   {% endif %}
   {% if km.start_extruder_preheat_scale > 1.0 or
         km.start_extruder_preheat_scale < 0.0 %}

--- a/heaters.cfg
+++ b/heaters.cfg
@@ -31,7 +31,7 @@ gcode:
       {% set MINIMUM = (((MINIMUM + scales.bump) * scales.scale, scales.minimum)
                         | max, scales.maximum)|min %}
     {% endif %}
-    {% if "MAXIMUM" in params and MINIMUM > 0.0 %}
+    {% if "MAXIMUM" in params and MAXIMUM > 0.0 %}
       {% set MAXIMUM = (((MAXIMUM + scales.bump) * scales.scale, scales.minimum)
                         | max, scales.maximum)|min %}
     {% endif %}

--- a/start_end.cfg
+++ b/start_end.cfg
@@ -44,7 +44,11 @@ gcode:
   {% if actions_at_temp %}
     # If we're going to run a bed level we heat the extruder only part way to
     # avoid oozing all over the bed while probing.
-    M104 S{(km.start_extruder_preheat_scale * EXTRUDER)|round(0,'ceil')|int}
+    {% if km.start_extruder_temperature > 0  %}
+      M104 S{km.start_extruder_temperature|float}
+    {% else %}
+      M104 S{(km.start_extruder_preheat_scale * EXTRUDER)|round(0,'ceil')|int}
+    {% endif %}
   {% else %}
     M104 S{EXTRUDER}
   {% endif %}

--- a/start_end.cfg
+++ b/start_end.cfg
@@ -44,7 +44,7 @@ gcode:
   {% if actions_at_temp %}
     # If we're going to run a bed level we heat the extruder only part way to
     # avoid oozing all over the bed while probing.
-    {% if km.start_extruder_temperature > 0  %}
+    {% if km.start_extruder_temperature > 0.0  %}
       M104 S{km.start_extruder_temperature|float}
     {% else %}
       M104 S{(km.start_extruder_preheat_scale * EXTRUDER)|round(0,'ceil')|int}


### PR DESCRIPTION
Hi

I've fixed a small conditional check for MAXIMUM in the temperature_wait_scaled macro and added a start_extruder_temperature setting to set the extruder to a fixed temperature instead of a scale of the target.

I'm running a nozzle cleaning macro before a print, so the extruder must come to the required print temp to purge and clean before starting KM's print_start. Voron Tap checks the bed at a max temp of 150C, so there's a wait for the extruder to come down from the higher temp. Then there's an additional wait for the extruder to come to the scaled temp. By setting a fixed temp to 150 there's no wait after the initial one, so I added an option for it.

start_extruder_preheat_scale must be set to 0 to use start_extruder_temperature