### PR TITLE
pause_resume_cancel: No virtual_sdcard checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ gcode:
 [save_variables]
 filename: ~/printer_data/variables.cfg # UPDATE THIS FOR YOUR PATH!!!
 
-[virtual_sdcard]
+[virtual_sdcard]    # Optional, for LCD menus
 path: ~/gcode_files # UPDATE THIS FOR YOUR PATH!!!
 
 [display_status]

--- a/globals.cfg
+++ b/globals.cfg
@@ -106,8 +106,7 @@ gcode:
                               "idle_timeout" : ("gcode", "_KM_IDLE_TIMEOUT"),
                               "pause_resume" : None,
                               "respond" : None,
-                              "save_variables" : None,
-                              "virtual_sdcard" : None
+                              "save_variables" : None
                              } %}
   {% set custom_error = {
     "start_extruder_set_target_before_level" :

--- a/pause_resume_cancel.cfg
+++ b/pause_resume_cancel.cfg
@@ -14,29 +14,26 @@ gcode:
   # Beeps
   {% set B = (params.B|default(10))|float %}
 
-  {% if printer.virtual_sdcard.is_active %}
-    {% set position = printer.gcode_move.gcode_position %}
-    SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_x VALUE="{position.x}"
-    SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_y VALUE="{position.y}"
-    SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_z VALUE="{position.z}"
-    SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_e VALUE="{E}"
-    SAVE_GCODE_STATE NAME=_KM_PAUSE_OVERRIDE_STATE
-    _KM_PAUSE_BASE
-    M83
-    G1 E{'%.4f' % -E} F{km.load_speed}
-    PARK P=2{% for k in params|select("in", "XYZ") %}
-      {' '~k~'="'~params[k]~'"'}
+  {% set position = printer.gcode_move.gcode_position %}
+  SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_x VALUE="{position.x}"
+  SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_y VALUE="{position.y}"
+  SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_z VALUE="{position.z}"
+  SET_GCODE_VARIABLE MACRO=resume VARIABLE=saved_e VALUE="{E}"
+  SAVE_GCODE_STATE NAME=_KM_PAUSE_OVERRIDE_STATE
+  _KM_PAUSE_BASE
+  M83
+  G1 E{'%.4f' % -E} F{km.load_speed}
+  PARK P=2{% for k in params|select("in", "XYZ") %}
+    {' '~k~'="'~params[k]~'"'}
+  {% endfor %}
+  # Beep on pause if there's an M300 macro.
+  {% if "output_pin beeper" in printer %}
+    {% for i in range(B|int) %}
+      M300 P100
+      G4 P200
     {% endfor %}
-    # Beep on pause if there's an M300 macro.
-    {% if "output_pin beeper" in printer %}
-      {% for i in range(B|int) %}
-        M300 P100
-        G4 P200
-      {% endfor %}
-    {% endif %}
-  {% else %}
-    { action_respond_info("Print from SD card is not in progress.") }
   {% endif %}
+
 
 [gcode_macro m600]
 description: Pauses the current print.


### PR DESCRIPTION
When printing outside of octoprint (mainsail) the virtual_sdcard interface is not used. This causes error when trying to pause the print:
"Print from SD card is not in progress."
In case this check is needed, maybe could be replaced with:
`printer.print_stats.state == "printing"`