### PR TITLE
Fixed "G20" when "G29" was intended in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,10 +954,10 @@ related commands, such as accelleration, jerk, and linear advance.
 
 ### Bed Mesh
 
-`BED_MESH_CALIBRATE` and `G20`
+`BED_MESH_CALIBRATE` and `G29`
 
 Overrides the default `BED_MESH_CALIBRATE` to use `BED_MESH_CALIBRATE_FAST`
-instead, and adds the `G20` command.
+instead, and adds the `G29` command.
 
 ***Configuration:***
 


### PR DESCRIPTION
This section (describing the optional bed_mesh configuration) adds G29 (mesh bed leveling), but the README said "G20", which is "Inch units". This fixes this.