### PR TITLE
fix pause at position

### DIFF
--- a/pause_resume_cancel.cfg
+++ b/pause_resume_cancel.cfg
@@ -31,9 +31,7 @@ gcode:
     {% if printer.extruder.can_extrude %}
       G1 E{'%.4f' % -E} F{km.load_speed}
     {% endif %}
-    PARK P=2{% for k in params|select("in", "XYZ") %}
-      {' '~k~'="'~params[k]~'"'}
-    {% endfor %}
+    PARK P=2{% for k in params|select("in", "XYZ") %}{' '~k~'="'~params[k]~'"'}{% endfor %}
     # Beep on pause if there's an M300 macro.
     {% for i in range(B) %}
       M300 P100


### PR DESCRIPTION
The format must have broken this as it is attempting to exectute it as
```
PARK P=2
X="10"
Y="10"
```

which fails because `X="10"` is an invalid command