### PR TITLE
Add feature to only use filament sensor while printing

### DIFF
--- a/globals.cfg
+++ b/globals.cfg
@@ -91,6 +91,8 @@ variable_start_z_tilt_adjust_at_temp: True
 variable_travel_speed_xy: 3000
 # Z travel speed in (mm/m) for movement macros.
 variable_travel_speed_z: 600
+# Switch named filament sensors based on PRINT_START(ON) and PRINT_END(OFF)
+variable_switch_filament_sensors: [] # example: ['toolhead_runout']
 ################################################################################
 description: Initializes our globals, including any _km_options overrides.
 gcode:

--- a/start_end.cfg
+++ b/start_end.cfg
@@ -228,6 +228,12 @@ gcode:
     _KM_PARK_IF_NEEDED HEATER={printer.toolhead.extruder} RANGE=ABOVE
     M109 S{EXTRUDER}
   {% endif %}
+
+  # Enable filament sensors
+  {% for sensor in km.switch_filament_sensors %}
+    SET_FILAMENT_SENSOR SENSOR={sensor} ENABLE=1
+  {% endfor %}
+
   PRINT_START_SET PRINT_START_PHASE="purge"
 
 [gcode_macro _print_start_phase_purge]
@@ -351,6 +357,11 @@ gcode:
   _PRINT_END_INNER
 
   {% set km = printer["gcode_macro _km_globals"] %}
+
+  # Disable filament sensors
+  {% for sensor in km.switch_filament_sensors %}
+    SET_FILAMENT_SENSOR SENSOR={sensor} ENABLE=0
+  {% endfor %}
 
   {% if km.start_clear_adjustments_at_end != 0 %}
     RESET_HEATER_SCALING


### PR DESCRIPTION
When having a filament sensor, by default they are ON, causing unloading/loading events to trigger even if we don't want to (hand feed or preparation).

```ini
[filament_switch_sensor toolhead_runout]
pause_on_runout: true
runout_gcode:
    M117 Runout Detected
    UNLOAD_FILAMENT
insert_gcode:
    M117 Insert Detected
    LOAD_FILAMENT
switch_pin: ^P1.28
```

We can disable the sensor by default using:

```ini
[delayed_gcode DISABLE_FILAMENT_SENSOR]
initial_duration: 1
gcode:
    SET_FILAMENT_SENSOR SENSOR=toolhead_runout ENABLE=0
```

However, this introduces another problem, we want the sensor ON when printing, but OFF when not printing, as so, this PR allows the user to select a list of sensors to switch ON/OFF on those print events.
This will allow user to do any handling of the extruder without the annoyance of removing the filament and it trigger an `PAUSE` which do `HOME`, `PREHEAT`, `PARK` and `UNLOAD` or insert the filament in cold just to prepare a future print and it trigger another unrequired sequence of events.

We could use slicer start and end gcode, but that is ugly, don't handle print cancel and make them less sharable. 
This integrated solution is cleaner and less prompt to error.

Usage:
```
variable_switch_filament_sensors: ['toolhead_runout'] # example: ('toolhead_runout')
```

