### PR TITLE
Continue when hotend temp above target when probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,12 @@ These are the customization options you can add to your
   probing that use the nozzle directly. When this value is provided
   `variable_start_extruder_preheat_scale` is ignored.
 
+* `variable_start_extruder_probing_temp_fast_forward` *(default: False)* - If set to a True
+  AND the current extruder temperature is above `start_extruder_probing_temp`,
+  the extruder will not be stabilized at the probing temperature before bed probing.
+  This is useful to skip the wait for the extruder temperature to cool down,
+  after for example, a previous print has ended/failed.
+
 * `variable_start_level_bed_at_temp` *(default: True if `bed_mesh` configured
   )* - If true the `PRINT_START` macro will run [`BED_MESH_CALIBRATE_FAST`](
   #bed-mesh-improvements) after the bed has stabilized at its target

--- a/globals.cfg
+++ b/globals.cfg
@@ -67,6 +67,8 @@ variable_start_end_park_y: 0.0 # Defaults to print_max Y.
 variable_start_extruder_preheat_scale: 0.5
 # If non-zero the extruder will stabilize at this temp before probing the bed.
 variable_start_extruder_probing_temp: 0
+# If we should skip the wait for extruder to cool down if extruder temp above start_extruder_probing_temp
+variable_start_extruder_probing_temp_fast_forward: False
 # Set to rehome Z in PRINT_START after bed temp stabilizes; False to disable.
 variable_start_home_z_at_temp: True
 # Set to level bed in PRINT_START after bed temp stabilizes; False to disable.

--- a/start_end.cfg
+++ b/start_end.cfg
@@ -186,9 +186,13 @@ gcode:
                            start_home_z_at_temp %}
   {% if actions_at_temp %}
     {% if km.start_extruder_probing_temp > 0 %}
-      _KM_PRINT_STATUS ACTION=CHANGE STATUS=extruder_heating RESET_STACK=1
-      _KM_PARK_IF_NEEDED HEATER={printer.toolhead.extruder} RANGE=2
-      M109 R{km.start_extruder_probing_temp}
+      {% if km.start_extruder_probing_temp_fast_forward %} # Check if we should cool extruder if current extruder temperature higher than target temp
+        M109 S{km.start_extruder_probing_temp}
+      {% else %}
+        _KM_PRINT_STATUS ACTION=CHANGE STATUS=extruder_heating RESET_STACK=1
+        _KM_PARK_IF_NEEDED HEATER={printer.toolhead.extruder} RANGE=2
+        M109 R{km.start_extruder_probing_temp}
+      {% endif %}
     {% else %}
       M104 S{EXTRUDER} # set the final extruder target temperature
     {% endif %}


### PR DESCRIPTION
This commit prevents the probing procedure to wait for the hotend temperature to settle if its above the target temperature. This is desired, if for example, the first layer failed and the print must be restarted.

We would be forced to wait until the temperature has fallen, depending on the chamber environment and hotend,
this could take several minutes.

Instead we ignore if its above and continue with probing, this saves time, especially when prototyping. It shouldn't be a problem anyways.