### PR TITLE
IDEX printer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ gcode: # This line is required by Klipper.
 # to your Z endstop or probe offset.
 #  ADJUST_SURFACE_OFFSETS
 
+# # Hook running before homing Z. Useful when specific things need to be done
+# # before Z homing
+# # This sample moves T1 toolhead out of the way so T0 can move to the safe_z_home
+# # position 
+# [gcode_macro _before_z_home]
+# gcode:
+#   T1 
+#   PARK
+#   T0
+
 # This line includes all the standard macros.
 [include klipper-macros/*.cfg]
 # Uncomment to include features that require specific hardware support.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ modifications are likely to break things in very unexpected ways.
 #  {'name' : 'ABS',  'extruder' : 245.0, 'bed' : 110.0, 'chamber' : 60}]
 # Length of filament (in millimeters) to purge at print start.
 #variable_start_purge_length: 30 # This value works for most setups.
+# Homing sequence ('xyz' or 'xy-z')
+# 'xy-z' opens the possibility to include a gcode hook '_BEFORE_Z_HOME'
+# to run before homing the Z axis
+#variable_homing_sequence: 'xyz'
+
 gcode: # This line is required by Klipper.
 # Any code you put here will run at klipper startup, after the initialization
 # for these macros. For example, you could uncomment the following line to
@@ -204,8 +209,9 @@ gcode: # This line is required by Klipper.
 # to your Z endstop or probe offset.
 #  ADJUST_SURFACE_OFFSETS
 
-# # Hook running before homing Z. Useful when specific things need to be done
-# # before Z homing
+# # Hook running before homing Z. 
+# # Used only if variable_homing_sequence is set to 'xy-z'
+# # Useful when specific things need to be done before Z homing
 # # This sample moves T1 toolhead out of the way so T0 can move to the safe_z_home
 # # position 
 # [gcode_macro _before_z_home]
@@ -213,6 +219,7 @@ gcode: # This line is required by Klipper.
 #   T1 
 #   PARK
 #   T0
+
 
 # This line includes all the standard macros.
 [include klipper-macros/*.cfg]

--- a/globals.cfg
+++ b/globals.cfg
@@ -91,6 +91,11 @@ variable_start_z_tilt_adjust_at_temp: True
 variable_travel_speed_xy: 3000
 # Z travel speed in (mm/m) for movement macros.
 variable_travel_speed_z: 600
+# Homing sequence ('xyz' or 'xy-z')
+# 'xy-z' will enable _BEFORE_Z_HOME macro
+variable_homing_sequence: 'xyz'
+
+
 ################################################################################
 description: Initializes our globals, including any _km_options overrides.
 gcode:
@@ -315,6 +320,9 @@ gcode:
   {% endif %}
   {% if km.load_priming_length < 0.0 %}
     {% set dummy = output.append("load_priming_length is negative.") %}
+  {% endif %}
+  {% if km.homing_sequence|lower not in ['xyz', 'xy-z']  %}
+    {% set dummy = output.append("homing_sequence should be 'xyz' or 'xy-z'.") %}
   {% endif %}
 
   # Emit all the config errors.

--- a/kinematics.cfg
+++ b/kinematics.cfg
@@ -41,18 +41,27 @@ gcode:
   # Find the real g28 command.
   {% set G28 = (printer["gcode_macro list_macros"].macros.g28|
                   default(["g28"],True))[-1] %}
-  {% set axes = 'XYZ'|select('in', params.AXES|default("XYZ")|upper|list) %}
+  {% set axes = 'XYZ'|select('in', params.AXES|default("XYZ")|upper|list)|list %}
   {% if not axes %} # No axes means home everything.
     {% set axes = 'XYZ' %}
   {% endif %}
   {% if params.LAZY|default(1)|int %} # Prune out the already homed axes.
-    {% set axes = axes|reject('in', printer.toolhead.homed_axes|upper)|join() %}
+    {% set axes = axes|reject('in', printer.toolhead.homed_axes|upper)|list %}
   {% endif %}
 
   {% if axes %}
     _KM_PRINT_STATUS ACTION=PUSH_STATUS
     _KM_PRINT_STATUS ACTION=CHANGE STATUS=homing
-    {G28}{% for k in axes %}{' ' ~ k}{% endfor %}
+    {% set h_axes = 'XY'|list|select('in', axes)|list %}
+    {% if h_axes %}
+      {G28} {% for a in h_axes %} { a }{% endfor %}
+    {% endif %}
+    {% if 'Z' in axes %}
+      {% if '_before_z_home' in printer["gcode_macro list_macros"].macros %}
+        _BEFORE_Z_HOME
+      {% endif %}
+      {G28} Z
+    {% endif %}
     _KM_PRINT_STATUS ACTION=CHANGE STATUS=pop_status
   {% endif %}
 

--- a/kinematics.cfg
+++ b/kinematics.cfg
@@ -44,7 +44,7 @@ gcode:
                   default(["g28"],True))[-1] %}
   {% set axes = 'XYZ'|select('in', params.AXES|default("XYZ")|upper|list)|list %}
   {% if not axes %} # No axes means home everything.
-    {% set axes = 'XYZ' %}
+    {% set axes = 'XYZ'|list %}
   {% endif %}
   {% if params.LAZY|default(1)|int %} # Prune out the already homed axes.
     {% set axes = axes|reject('in', printer.toolhead.homed_axes|upper)|list %}
@@ -53,13 +53,10 @@ gcode:
   {% if axes %}
     _KM_PRINT_STATUS ACTION=PUSH_STATUS
     _KM_PRINT_STATUS ACTION=CHANGE STATUS=homing
-      RESPOND MSG="{ km.homing_sequence|lower }"
     {% if km.homing_sequence|lower == 'xyz' %}
-      RESPOND MSG="XYZ"
       {G28} {% for a in axes %} { a }{% endfor %}
     {% else %}
-      {% if km.homing_sequence|lower == 'xy-z' %} 
-        RESPOND MSG="XY-Z"
+      {% if km.homing_sequence|lower == 'xy-z' %}
         {% set h_axes = 'XY'|list|select('in', axes)|list %}
         {% if h_axes %}
           {G28} {% for a in h_axes %} { a }{% endfor %}

--- a/kinematics.cfg
+++ b/kinematics.cfg
@@ -38,6 +38,7 @@ gcode:
 
 [gcode_macro _lazy_home_inner]
 gcode:
+  {% set km = printer["gcode_macro _km_globals"] %}
   # Find the real g28 command.
   {% set G28 = (printer["gcode_macro list_macros"].macros.g28|
                   default(["g28"],True))[-1] %}
@@ -52,15 +53,24 @@ gcode:
   {% if axes %}
     _KM_PRINT_STATUS ACTION=PUSH_STATUS
     _KM_PRINT_STATUS ACTION=CHANGE STATUS=homing
-    {% set h_axes = 'XY'|list|select('in', axes)|list %}
-    {% if h_axes %}
-      {G28} {% for a in h_axes %} { a }{% endfor %}
-    {% endif %}
-    {% if 'Z' in axes %}
-      {% if '_before_z_home' in printer["gcode_macro list_macros"].macros %}
-        _BEFORE_Z_HOME
+      RESPOND MSG="{ km.homing_sequence|lower }"
+    {% if km.homing_sequence|lower == 'xyz' %}
+      RESPOND MSG="XYZ"
+      {G28} {% for a in axes %} { a }{% endfor %}
+    {% else %}
+      {% if km.homing_sequence|lower == 'xy-z' %} 
+        RESPOND MSG="XY-Z"
+        {% set h_axes = 'XY'|list|select('in', axes)|list %}
+        {% if h_axes %}
+          {G28} {% for a in h_axes %} { a }{% endfor %}
+        {% endif %}
+        {% if 'Z' in axes %}
+          {% if '_before_z_home' in printer["gcode_macro list_macros"].macros %}
+            _BEFORE_Z_HOME
+          {% endif %}
+          {G28} Z
+        {% endif %}
       {% endif %}
-      {G28} Z
     {% endif %}
     _KM_PRINT_STATUS ACTION=CHANGE STATUS=pop_status
   {% endif %}


### PR DESCRIPTION
Homing sequence became configurable:
- `xyz`: X,Y,Z handled by Klipper
- `xy-z`: X,Y handled by Klipper, `_BEFORE_Z_HOME` macro (optional), then Z

The need arose when configuring an IDEX machine and Z homing failed because the primary toolhead didn't have the clearance to move to the `safe_z_home` position. With this modification, one can define a script to park a secondary toolhead to make room for the homing.